### PR TITLE
[#95695338] Parameterise the tsuru api endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Role Variables
 
 `gandalf_git_template_dir` directory where git templates are stored.
 
+`tsuru_api_endpoint` uri to tsuru api, defaults to `http://localhost:8080`
+
 Dependencies
 ------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@
 
 gandalf_port: 8080
 gandalf_git_template_dir: /home/git/bare-template
+tsuru_api_endpoint: http://localhost:8080

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
     - restart archive-server
 
 - name: Add api endpoint to bash_profile
-  lineinfile: 'create=yes dest=/home/git/.bash_profile line="export TSURU_HOST=http://{{tsuru_api_internal_lb}}:8080"'
+  lineinfile: 'create=yes dest=/home/git/.bash_profile line="export TSURU_HOST={{ tsuru_api_endpoint }}"'
   notify:
     - restart gandalf
     - restart archive-server


### PR DESCRIPTION
Allow the `tsuru api` endpoint to be completely parameterized so it can
use other protocols e.g. `https`.
