### PR TITLE
[#98748824] Add support for version pinning the archive and gandalf servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Role Variables
 
 `tsuru_api_endpoint` uri to tsuru api, defaults to `http://localhost:8080`
 
+`archive_server_version` version of the archive server you wish to install, defaults to `latest`
+
+`gandalf_server_version` version of the gandalf server you wish to install, defaults to `latest`
+
 Dependencies
 ------------
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,22 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+MEMORY_DEFAULT = 512
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.hostname = "gandalf"
+
+  config.vm.provider :virtualbox do |v|
+    v.memory = MEMORY_DEFAULT
+  end
+
+  config.vm.provider :vmware_fusion do |v|
+    v.vmx["memsize"] = MEMORY_DEFAULT
+  end
+
+  config.vm.provision :shell, inline: "apt-get purge -qq -y --auto-remove chef puppet"
+  config.vm.provision :ansible do |ansible|
+    ansible.playbook = "site.yml"
+  end
+end

--- a/site.yml
+++ b/site.yml
@@ -1,0 +1,10 @@
+---
+- hosts: all
+  sudo: yes
+  vars:
+    - gandalf_host_internal: localhost
+    - mongodb_host: localhost
+    - mongodb_port: '27001'
+    - gandalf_host_external: localhost
+  roles:
+    - .

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,8 +9,8 @@
   with_items:
     - curl
     - python-software-properties
-    - gandalf-server
-    - archive-server
+    - "{% if gandalf_server_version is defined %}gandalf-server={{ gandalf_server_version }}{% else %}gandalf-server{% endif %}"
+    - "{% if archive_server_version is defined %}archive-server={{ archive_server_version }}{% else %}archive-server{% endif %}"
 
 - name: Create git hook directory.
   file: path={{ gandalf_git_template_dir }}/hooks state=directory owner=git group=git recurse=yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,11 @@
 
 - name: Install packages.
   apt: update_cache=true name="{{ item }}"
-  with_items: packages
+  with_items:
+    - curl
+    - python-software-properties
+    - gandalf-server
+    - archive-server
 
 - name: Create git hook directory.
   file: path={{ gandalf_git_template_dir }}/hooks state=directory owner=git group=git recurse=yes

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,9 +1,2 @@
 ---
 # vars file for gandalf
-
-packages:
-  - curl
-  - python-software-properties
-  - gandalf-server
-  - archive-server
-


### PR DESCRIPTION
[Pin the versions of components that we use](https://www.pivotaltracker.com/story/show/98748824)

**What**

To prevent breaking changes of components (e.g. Tsuru API, MongoDB, etc) causing the platform to break we should pin or build to a particular version, this will ensure a consistent build.

This PR adds version control for the [archive server](https://github.com/tsuru/archive-server) and the [gandalf api](https://github.com/tsuru/gandalf)

**How to review this PR**

This PR has been written to be reviewed in the following context:
- I want to create a vagrant environment to help me develop and test locally
- I want to parameterise some of the packages so I would like to move them into the `task/main.yml` file so they are easier to find and modify
- I want to specifically allow the `archive server` and the `gandalf api` to be pinned to a specific version
- I want to update the documentation so others know how to pin a specific version of the `archive server` and the `gandalf api`

**How to test this PR**

A vagrant box has been provided for testing.

```
$ vagrant up
```

You can supply the following snippet to the `site.yml` for testing version pinning:

```
vars:
  - archive_server_version: 0.1.2-0~trusty1
  - gandalf_server_version: 0.7.0-0~trusty1
```

**Who should review this PR**
- Any one in the world, man, woman, child or chicken!
