### PR TITLE
[#99420212] Variabilise the name of the Tsuru PPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Role Variables
 
 `gandalf_server_version` version of the gandalf server you wish to install, defaults to `latest`
 
+`tsuru_repo` repo argument for Ansible's [`apt_repository`](http://docs.ansible.com/ansible/apt_repository_module.html) module, defaults to `ppa:tsuru/ppa`
+
 Dependencies
 ------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,4 @@
 gandalf_port: 8080
 gandalf_git_template_dir: /home/git/bare-template
 tsuru_api_endpoint: http://localhost:8080
+tsuru_ppa: tsuru/ppa

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,4 +4,4 @@
 gandalf_port: 8080
 gandalf_git_template_dir: /home/git/bare-template
 tsuru_api_endpoint: http://localhost:8080
-tsuru_ppa: tsuru/ppa
+tsuru_repo: 'ppa:tsuru/ppa'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for gandalf
 
 - name: Add tsuru repositories.
-  apt_repository: repo="ppa:{{ tsuru_ppa }}" update_cache=yes
+  apt_repository: repo="{{ tsuru_repo }}" update_cache=yes
 
 - name: Install packages.
   apt: update_cache=true name="{{ item }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for gandalf
 
 - name: Add tsuru repositories.
-  apt_repository: repo='ppa:tsuru/ppa' update_cache=yes
+  apt_repository: repo="ppa:{{ tsuru_ppa }}" update_cache=yes
 
 - name: Install packages.
   apt: update_cache=true name="{{ item }}"


### PR DESCRIPTION
So that we can point it at our own PPA which contains copies of the packages
at the versions we want to use. This is to workaround a limitation of
Launchpad PPAs which only allow you to download the latest version of a
package.

I can't see any nice way (with Ansible) to remove the old repo if you've
specified a custom one, because another playbook (tsuru_api/gandalf/hipache)
may still configure the original repo and both tasks would fight (changing
it back and forth in every run).

So if we use this, we'll also want to either a) remove the old repo as a
custom task outside of these playbooks, or b) specify the package versions
we want so that the old repo is ignored if it presents a later version.

---

Shout if you have a opinion/preference for a) or b).
